### PR TITLE
Fixing Node version for npm install + removing duplicate method

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -49,5 +49,10 @@
     "deploymentDirectory": "deployment",
     "sourceDirectory": "src/main",
     "testDirectory": "src/test"
+  },
+  "engineStrict": true,
+  "engines": {
+    "node": "4.4.7",
+    "npm": "2.15.8"
   }
 }

--- a/client/src/main/js/views/dashboard/payment/view-pricing-options.js
+++ b/client/src/main/js/views/dashboard/payment/view-pricing-options.js
@@ -13,10 +13,6 @@ var PricingOptions = React.createClass({
 		Router.Navigation
 	],
 
-    onChooseBeta: function() {
-        this.transitionTo('stripePayment', {price: '$1'});
-    },
-
 	onChoosePremium: function() {
 		this.transitionTo('stripePayment', {price: 'premium'});
 	},


### PR DESCRIPTION
#### CHANGE SUMMARY

* New versions of node don't install npm dependencies properly. Until we upgrade libraries, fixing node and npm version. (Use node managers like `n` or `nvm` to make this switch easier.
* There was a duplicate method in `view-pricing-options.js` that was preventing compilation.